### PR TITLE
Update README - Add user option to docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In your .bashrc, .zshrc, or similar file include aliases for the
 following commands:
 
 ```
-alias vue='docker run -it --rm -v "$PWD":"$PWD" -w "$PWD" ebiven/vue-cli vue'
+alias vue='docker run -it --rm -v "$PWD":"$PWD" -w "$PWD" -u "$(id -u)" ebiven/vue-cli vue'
 ```
 
 Using this via docker-compose:


### PR DESCRIPTION
Add user to prevent errors like this:

```
   vue-cli · Failed to write the file at: /home/avonrent/git/vue-tutorial/16 - vue-loader/hello-vue/.gitignore

EACCES: permission denied, mkdir '/home/avonrent/git/vue-tutorial/16 - vue-loader/hello-vue'
``` 